### PR TITLE
Fix: array dimension of o now 1 (at compile time it was 0)

### DIFF
--- a/README
+++ b/README
@@ -57,3 +57,6 @@ OS X.
 20220517 Updated MOD files to contain valid C++ and be compatible with
 the upcoming versions 8.2 and 9.0 of NEURON. Updated to use post ~2011
 signature of mcell_ran4_init function and fix hashseed2 argument.
+
+20230228 Fix error due to inconsistent array dimensions. Required by
+https://github.com/neuronsimulator/nrn/pull/2024 in NEURON 9+.

--- a/nqs.hoc
+++ b/nqs.hoc
@@ -2619,7 +2619,12 @@ proc sv () { local i,j,cd,cd1,vers,a,aflag,nx,no,ns,svinfo localobj xo,v1,v2
   if (svinfo) {
     savenums(nx,no,ns) 
     if (nx>0) savenums(&info.x,nx)
-    for ii=0,no-1 {xo=info.o(ii) if (isojt(xo,v)) xo.vwrite(tmpfile) }
+    for ii=0,no-1 {
+      xo=info.o[ii]
+      if (isojt(xo,v)) {
+        xo.vwrite(tmpfile)
+      }
+    }
     if (ns>0) wrvstr(info.s) if (ns>1) wrvstr(info.t) 
     if (ns>2) wrvstr(info.u) if (ns>3) wrvstr(info.v) 
   }
@@ -2684,7 +2689,10 @@ func rd () { local n,vers,hflag,cd,cd1,cd3,cd4,ii,oco,nx,no,ns,svinfo localobj v
   if (svinfo) {
     readnums(&nx,&no,&ns) 
     if (nx>0) readnums(&info.x[0])
-    for ii=0,no-1 {info.o(ii)=new Vector() info.o(ii).vread(tmpfile) }
+    for ii=0,no-1 {
+      info.o[ii] = new Vector()
+      info.o[ii].vread(tmpfile)
+    }
     if (ns>0) rdvstr(info.s) if (ns>1) rdvstr(info.t) 
     if (ns>2) rdvstr(info.u) if (ns>3) rdvstr(info.v) 
   }


### PR DESCRIPTION
Fix error introduced by https://github.com/neuronsimulator/nrn/pull/2024.
This appears in the comparison between `neuron` and `neuron-nightly` in https://github.com/neuronsimulator/nrn-modeldb-ci/.
This fix was already present in https://github.com/ModelDBRepository/146949/pull/2, but that is less ready to merge.